### PR TITLE
Work for 13 December 2024

### DIFF
--- a/beginner-course/Section 10 - Modules and Bundlers/73-date-picker/typescript-date-picker/index.html
+++ b/beginner-course/Section 10 - Modules and Bundlers/73-date-picker/typescript-date-picker/index.html
@@ -39,6 +39,7 @@
           <input type="number" name="year-selector-search" id="year-selector-search" />
         </div>
         <div class="year-selector-grid" data-year-selector-grid></div>
+        <div class="hide" data-year-selector-no-matches-message>No matches were found.</div>
       </div>
       <div class="date-picker-grid-header date-picker-grid" data-date-picker-grid-header>
         <div>Sun</div>


### PR DESCRIPTION
- Add functionality to the year selector search bar; it now filters the year list and can be used to select a year by pressing the enter key
- Add a message to be displayed if the year list is filtered to be empty
- Small tweaks to consolidate common logic