### PR TITLE
Work for 24 January 2025

### DIFF
--- a/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.css
+++ b/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.css
@@ -1,0 +1,8 @@
+.disabled:disabled {
+	opacity: 0.75;
+	pointer-events: none;
+	background-color: #a0aec0;
+	background-color: rgba(160, 174, 192, 1);
+	color: #000;
+	color: rgba(0, 0, 0, 1);
+}

--- a/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.ts
+++ b/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.ts
@@ -1,30 +1,117 @@
-import { Item } from "./items.ts"
+import { getItem, Item } from "./items.ts"
+import formatCurrency from "./utilities.ts"
+
+// Persist using Session Storage or Local Storage
+// NOTE: Maps can't be serialized directly, so I need to convert it to an Array before serializing and saving. When deserializing, I can put the resulting Array directly into the Map constructor and it will give me the correct map.
+// TODO: Decide whether to use localStorage or sessionStorage. localStorage persists across browsing sessions, sessionStorage only lasts until the site is closed. I know Kyle used sessionStorage, but I'm on the fence. I feel like most real-world shopping cart applications (like Amazon) probably use something more like localStorage (though, in reality, they probably just have some server storage somewhere that persists your cart across all browsers and apps that you are signed in to).
+// 1. Load the cart from storage whenever the cart is rendered.
+// 2. Whenever the cart is updated, save it to storage.
+// 3. Whenever the cart details are toggled, update the state in storage.
+// 4. When something requests to render the cart, check in storage to see whether the details should be visible or not.
+type CartItemID = number
+type CartItemQuantity = number
+let cart: Map<CartItemID, CartItemQuantity> = new Map([
+	[1, 2],
+	[3, 1]
+])
+
+export function addToCart(id: number, quantity: number = 1) {
+	let previousQuantity = cart.get(id) ?? 0
+	cart.set(id, previousQuantity + quantity)
+	renderCart()
+}
+
+function removeFromCart(id: number) {
+	cart.delete(id)
+	renderCart()
+}
 
 // Cart Button:
-// 1. When clicked, toggle whether the cart contents are visible.
-// 2. When empty, hide the number bubble, disable the button, and change the SVG color to gray. // NOTE: I am having a very difficult time doing this with tailwind. Their disabled utility classes don't seem to work unless the element is in a form, which my button is not. I could potentially define my own classes that do the same thing, but I'm not sure I want to put in the effort. I'll think it over, but I may end up just hiding the cart entirely when it's empty, like Kyle did.
-// 3. Persist the cart state between pages. This means if the cart is open on one page, it should be open when visiting another page.
-const cart = document.querySelector("[data-cart]") as HTMLElement
-const cartToggleButton = cart.querySelector(
+// (DONE) 1. When clicked, toggle whether the cart contents are visible.
+// 2. When empty, hide the number bubble, disable the button, and change the SVG color to gray.
+const cartElement = document.querySelector("[data-cart]") as HTMLElement
+const cartToggleButton = cartElement.querySelector(
 	"[data-cart-toggle-button]"
 ) as HTMLButtonElement
-const cartDetails = cart.querySelector("[data-cart-details]") as HTMLDivElement
-// cartToggleButton.disabled = true
-cartToggleButton.addEventListener("click", e => {
+const cartDetails = cartElement.querySelector("[data-cart-details]") as HTMLDivElement
+cartToggleButton.addEventListener("click", () => {
 	cartDetails.classList.toggle("invisible")
 })
 
+// Cart Details
+// (DONE) 1. When the cart is rendered, update the number of items on the icon.
+// (DONE) 2. If the cart details are shown, rerender the items that are in the cart and update the total price whenever the cart is rendered.
+// BONUS: Add a button to clear all contents from the cart.
+// BONUS: Add a "compact" view to the cart that makes each cart item into one row. Add a toggle at the top to turn the "compact" view on and off.
+const cartItemList = cartDetails.querySelector("[data-cart-item-list]") as HTMLDivElement
+const cartTotalPrice = cartDetails.querySelector(
+	"[data-cart-total-price]"
+) as HTMLSpanElement
+const cartTotalItems = cartToggleButton.querySelector(
+	"[data-total-cart-items]"
+) as HTMLDivElement
+function renderCart() {
+	cartItemList.innerHTML = ""
+	let totalPrice = 0
+	let totalItems = 0
+	for (let [id, quantity] of cart) {
+		const item = getItem(id)
+		if (item === null) continue
+
+		totalPrice += quantity * item.priceCents
+		totalItems += quantity
+		cartItemList.appendChild(renderCartItem(item, quantity))
+	}
+	cartTotalPrice.textContent = formatCurrency(totalPrice / 100)
+	cartTotalItems.textContent = String(totalItems)
+}
+
 // Cart Item:
 // Structure: { id: number, quantity: number }
-// "id" will be used to look up the item in items.json and the resulting item will be used to populate the HTML.
-// 1. When the "x" button is clicked, remove the item from the cart.
-// BONUS: Add a way to increment and decrement the amount directly from the cart.
-// BONUS: Add a button to clear all contents from the cart.
-// BONUS: Add a "compact" view to the cart that makes each cart item into one row. In this view, clicking on an item will expand the row to show the quantity adjustment controls. Clicking the item again collapses the row and hides the quantity controls. Clicking another item also collapses the row and hides the quantity controls (only one row can be expanded at a time). Add a toggle at the top to turn the "compact" view on and off.
-const cartItemList = cart.querySelector("[data-cart-item-list]") as HTMLDivElement
+// "id" will be used to look up the item in items.ts and the resulting item will be used to populate the HTML.
+// When rendered:
+// (DONE) 1. Set the image color.
+// (DONE) 2. Add an event listener to the "x" button that removes the item from the cart.
+// (DONE) 3. Set the item's name.
+// (DONE) 4. Set the item's quantity. If the quantity is one, hide the quantity span.
+// (DONE) 5. Set the price.
+// TODO: Once I'm done implementing everything, the cart contents should be hidden by default.
+const cartItemTemplate = cartElement.querySelector(
+	"[data-cart-item-template]"
+) as HTMLTemplateElement
+function renderCartItem(item: Item, quantity: CartItemQuantity) {
+	const cartItemElement = cartItemTemplate.content.cloneNode(true) as HTMLDivElement
 
-// The cart should persist between pages by using Local Storage. Anytime the cart is updated (whether from the cart itself, or from the store page), Local Storage should be updated.
+	const image = cartItemElement.querySelector(
+		"[data-cart-item-image]"
+	) as HTMLImageElement
+	image.src = `https://dummyimage.com/210x130/${item.imageColor}/${item.imageColor}`
 
-export function addToCart(item: Item, quantity: number = 1) {
-	console.log(item.name, quantity)
+	const removeFromCartButton = cartItemElement.querySelector(
+		"[data-remove-from-cart-button]"
+	) as HTMLButtonElement
+	removeFromCartButton.addEventListener("click", () => {
+		removeFromCart(item.id)
+	})
+
+	const name = cartItemElement.querySelector(
+		"[data-cart-item-name]"
+	) as HTMLHeadingElement
+	name.textContent = item.name
+
+	const quantityElement = cartItemElement.querySelector(
+		"[data-cart-item-quantity]"
+	) as HTMLSpanElement
+	quantityElement.textContent = `x${quantity}`
+	if (quantity === 1) quantityElement.classList.add("invisible")
+
+	const price = cartItemElement.querySelector(
+		"[data-cart-item-price]"
+	) as HTMLDivElement
+	price.textContent = formatCurrency((item.priceCents * quantity) / 100)
+
+	return cartItemElement
 }
+
+// Render the cart when the page is loaded.
+renderCart()

--- a/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/store.ts
+++ b/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/store.ts
@@ -2,34 +2,34 @@ import { addToCart } from "./cart.ts"
 import { getItems, Item } from "./items.ts"
 import formatCurrency from "./utilities.ts"
 
-// 1 (DONE). Populate the items on the page dynamically. Make the "Add to Cart" button functional when creating each item.
-// BONUS (DONE): In the item layout, add a way to change the quantity before adding it to the cart and adjust the "Add to Cart" button to take into account the set quantity. The quantity should default to 1 to keep the same behavior as the "before" implementation.
+// (DONE) 1. Populate the items on the page dynamically. Make the "Add to Cart" button functional when creating each item.
+// (DONE) BONUS: In the item layout, add a way to change the quantity before adding it to the cart and adjust the "Add to Cart" button to take into account the set quantity. The quantity should default to 1 to keep the same behavior as the "before" implementation.
 const storeItemTemplate = document.querySelector(
 	"[data-store-item]"
 ) as HTMLTemplateElement
 
-function generateItemHTML(item: Item) {
-	const itemHTML = storeItemTemplate.content.cloneNode(true) as HTMLDivElement
+function renderStoreItem(item: Item) {
+	const itemElement = storeItemTemplate.content.cloneNode(true) as HTMLDivElement
 
-	const image = itemHTML.querySelector("[data-image]") as HTMLImageElement
+	const image = itemElement.querySelector("[data-image]") as HTMLImageElement
 	image.src = `https://dummyimage.com/420x260/${item.imageColor}/${item.imageColor}`
 
-	const category = itemHTML.querySelector("[data-category]") as HTMLHeadingElement
+	const category = itemElement.querySelector("[data-category]") as HTMLHeadingElement
 	category.textContent = item.category
 
-	const name = itemHTML.querySelector("[data-name]") as HTMLHeadingElement
+	const name = itemElement.querySelector("[data-name]") as HTMLHeadingElement
 	name.textContent = item.name
 
-	const price = itemHTML.querySelector("[data-price]") as HTMLParagraphElement
+	const price = itemElement.querySelector("[data-price]") as HTMLParagraphElement
 	price.textContent = formatCurrency(item.priceCents / 100)
 
-	const reduceQuantityButton = itemHTML.querySelector(
+	const reduceQuantityButton = itemElement.querySelector(
 		"[data-reduce-quantity-button]"
 	) as HTMLButtonElement
-	const increaseQuantityButton = itemHTML.querySelector(
+	const increaseQuantityButton = itemElement.querySelector(
 		"[data-increase-quantity-button]"
 	) as HTMLButtonElement
-	const quantityInput = itemHTML.querySelector(
+	const quantityInput = itemElement.querySelector(
 		"[data-quantity-input]"
 	) as HTMLInputElement
 	reduceQuantityButton.addEventListener("click", () => {
@@ -37,25 +37,25 @@ function generateItemHTML(item: Item) {
 		quantityInput.valueAsNumber--
 	})
 	increaseQuantityButton.addEventListener("click", () => {
-		// limit the quantity to 100; to change the limit, just change 99 to another number
+		// limit the quantity to 100; to change the limit, just change 100 to another number
 		// in a real-world setting, this could be set up to use the number of items that are in stock
 		// or a static value that is attached to the item somewhere in the database
-		if (quantityInput.valueAsNumber > 99) return
+		if (quantityInput.valueAsNumber >= 100) return
 		quantityInput.valueAsNumber++
 	})
 
-	const addToCartButton = itemHTML.querySelector(
+	const addToCartButton = itemElement.querySelector(
 		"[data-add-to-cart-button]"
 	) as HTMLButtonElement
 	addToCartButton.addEventListener("click", () => {
-		addToCart(item, quantityInput.valueAsNumber)
+		addToCart(item.id, quantityInput.valueAsNumber)
 	})
 
-	return itemHTML
+	return itemElement
 }
 
 const itemList = document.querySelector("[data-item-list]") as HTMLDivElement
 const items = getItems()
 for (let item of items) {
-	itemList.appendChild(generateItemHTML(item))
+	itemList.appendChild(renderStoreItem(item))
 }

--- a/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/store.html
+++ b/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/store.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="stylesheet" href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css">
+  <link rel="stylesheet" href="src/cart.css">
   <script type="module" src="src/store.ts"></script>
   <style>
     input::-webkit-outer-spin-button,
@@ -68,48 +69,15 @@
     <div class="mb-4 top-0 right-0 mr-4 mt-20 fixed" data-cart-details>
       <div style="max-height: calc(100vh - 6rem)"
         class="bg-white text-gray-700 body-font shadow-lg border rounded-lg flex flex-col">
-        <div class="overflow-y-auto px-4 pt-4" data-cart-item-list>
-          <div class="mb-6">
-            <div class="block relative h-24 rounded overflow-hidden">
-              <img src="https://dummyimage.com/210x130/F00/F00" alt="ecommerce"
-                class="object-cover object-center w-full h-full block rounded">
-              <button data-remove-from-cart-button
-                class="absolute top-0 right-0 bg-black rounded-tr text-white w-6 h-6 text-lg flex justify-center items-center">&times;</button>
-            </div>
-            <div class="mt-2 flex justify-between">
-              <div class="flex items-center title-font">
-                <h2 class="text-gray-900 text-lg font-medium">
-                  Red
-                </h2>
-                <span class="text-gray-600 text-sm font-bold ml-1">x2</span>
-              </div>
-              <div>$32.00</div>
-            </div>
-          </div>
-          <div class="mb-6">
-            <div class="block relative h-24 rounded overflow-hidden">
-              <img src="https://dummyimage.com/210x130/00F/00F" alt="ecommerce"
-                class="object-cover object-center w-full h-full block rounded">
-              <button data-remove-from-cart-button
-                class="absolute top-0 right-0 bg-black rounded-tr text-white w-6 h-6 text-lg flex justify-center items-center">&times;</button>
-            </div>
-            <div class="mt-2 flex justify-between">
-              <div class="flex items-center title-font">
-                <h2 class="text-gray-900 text-lg font-medium">
-                  Blue
-                </h2>
-              </div>
-              <div>$12.00</div>
-            </div>
-          </div>
-        </div>
+        <div class="overflow-y-auto px-4 pt-4" data-cart-item-list></div>
         <div class="flex justify-between items-end border-t p-4">
           <span class="font-bold text-lg uppercase">Total</span>
-          <span class="font-bold">$44.00</span>
+          <span class="font-bold" data-cart-total-price></span>
         </div>
       </div>
     </div>
-    <button class="fixed top-0 right-0 mr-4 mt-4 w-12 bg-blue-500 p-2 rounded-full text-white hover:bg-blue-700"
+    <button
+      class="fixed top-0 right-0 mr-4 mt-4 w-12 bg-blue-500 p-2 rounded-full text-white hover:bg-blue-700 disabled"
       data-cart-toggle-button>
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"
         data-cart-with-items-svg>
@@ -118,25 +86,22 @@
       </svg>
       </svg>
       <div
-        class="bg-red-500 rounded-full text-xs absolute w-6 h-6 flex justify-center items-center right-0 bottom-0 transform translate-x-2 translate-y-2">
-        2</div>
+        class="bg-red-500 rounded-full text-xs absolute w-6 h-6 flex justify-center items-center right-0 bottom-0 transform translate-x-2 translate-y-2"
+        data-total-cart-items></div>
     </button>
     <template data-cart-item-template>
       <div class="mb-6">
         <div class="block relative h-24 rounded overflow-hidden">
-          <img src="https://dummyimage.com/210x130/F00/F00" alt="ecommerce"
-            class="object-cover object-center w-full h-full block rounded">
+          <img alt="ecommerce" class="object-cover object-center w-full h-full block rounded" data-cart-item-image>
           <button data-remove-from-cart-button
             class="absolute top-0 right-0 bg-black rounded-tr text-white w-6 h-6 text-lg flex justify-center items-center">&times;</button>
         </div>
         <div class="mt-2 flex justify-between">
           <div class="flex items-center title-font">
-            <h2 class="text-gray-900 text-lg font-medium">
-              Red
-            </h2>
-            <span class="text-gray-600 text-sm font-bold ml-1">x2</span>
+            <h2 class="text-gray-900 text-lg font-medium" data-cart-item-name></h2>
+            <span class="text-gray-600 text-sm font-bold ml-1" data-cart-item-quantity></span>
           </div>
-          <div>$32.00</div>
+          <div data-cart-item-price></div>
         </div>
       </div>
     </template>


### PR DESCRIPTION
- add CSS specifically for the cart to achieve the "disabled" look and effect I wanted but was unable to get with the Tailwind CDN
- change the naming convention in the store TypeScript file to match the convention used in the cart TypeScript file
- on the store page, change the quantity input limit to be >=100 instead of >99
- on the store page, pass the item id when adding an item to the cart instead of passing the whole item
- remove hard-coded data from the cart item template and the cart section of the store page
- implement a basic cart that can be used to help implement the remaining features aside from persistence
- set up the cart details rendering and make them toggleable