### PR TITLE
Work for 26 January 2025

### DIFF
--- a/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/store.html
+++ b/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/store.html
@@ -69,6 +69,27 @@
     <div class="mb-4 top-0 right-0 mr-4 mt-20 fixed" data-cart-details>
       <div style="max-height: calc(100vh - 6rem)"
         class="bg-white text-gray-700 body-font shadow-lg border rounded-lg flex flex-col">
+        <div class="flex justify-end items-end border-b p-2 gap-2">
+          <button class="w-6" title="Use compact view" data-compact-view-button>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" data-compact-view-off>
+              <title>Use compact view</title>
+              <path
+                d="M11 15H17V17H11V15M9 7H7V9H9V7M11 13H17V11H11V13M11 9H17V7H11V9M9 11H7V13H9V11M21 5V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H19C20.1 3 21 3.9 21 5M19 5H5V19H19V5M9 15H7V17H9V15Z" />
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" data-compact-view-on class="hidden">
+              <title>Use compact view</title>
+              <path
+                d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3M7 7H9V9H7V7M7 11H9V13H7V11M7 15H9V17H7V15M17 17H11V15H17V17M17 13H11V11H17V13M17 9H11V7H17V9Z" />
+            </svg>
+          </button>
+          <button class="w-6" title="Clear cart" data-clear-cart-button>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <title>Clear cart</title>
+              <path
+                d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z" />
+            </svg>
+          </button>
+        </div>
         <div class="overflow-y-auto px-4 pt-4" data-cart-item-list></div>
         <div class="flex justify-between items-end border-t p-4">
           <span class="font-bold text-lg uppercase">Total</span>
@@ -89,7 +110,24 @@
         class="bg-red-500 rounded-full text-xs absolute w-6 h-6 flex justify-center items-center right-0 bottom-0 transform translate-x-2 translate-y-2"
         data-total-cart-items></div>
     </button>
-    <template data-cart-item-template>
+    <!-- <template data-full-cart-item-template>
+      <div class="mb-6">
+        <div class="block relative h-24 rounded overflow-hidden">
+          <img alt="ecommerce" class="object-cover object-center w-full h-full block rounded" data-cart-item-image>
+          <button data-remove-from-cart-button
+            class="absolute top-0 right-0 bg-black rounded-tr text-white w-6 h-6 text-lg flex justify-center items-center">&times;</button>
+        </div>
+        <div class="mt-2 flex justify-between">
+          <div class="flex items-center title-font">
+            <h2 class="text-gray-900 text-lg font-medium" data-cart-item-name></h2>
+            <span class="text-gray-600 text-sm font-bold ml-1" data-cart-item-quantity></span>
+          </div>
+          <div data-cart-item-price></div>
+        </div>
+      </div>
+    </template> -->
+    <!-- Transform this template into the compact view template -->
+    <template data-full-cart-item-template>
       <div class="mb-6">
         <div class="block relative h-24 rounded overflow-hidden">
           <img alt="ecommerce" class="object-cover object-center w-full h-full block rounded" data-cart-item-image>


### PR DESCRIPTION
- add a row of controls at the top of the cart details
- duplicate the cart item template to prepare for creating the compact cart item template
- add the ability to clear all items from the cart
- add the ability to turn on a compact view in the cart; this does not actually change how the cart displays items yet
- when the cart is empty, hide the bubble that displays the number of items, disable the button, and turn the background gray